### PR TITLE
fixup exception handling and add helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,6 @@ include $(TOP)/configure/CONFIG
 
 DIRS += cpp
 DIRS += test/cpp
+test/cpp_DEPEND_DIRS = cpp
 
 include $(TOP)/configure/RULES_TOP

--- a/cpp/src/Makefile
+++ b/cpp/src/Makefile
@@ -2,9 +2,12 @@
 TOP = ..
 include $(TOP)/configure/CONFIG
 
+DIRS += util
+
 DIRS += client
 
 DIRS += server
+server_DEPEND_DIRS = util
 
 DIRS += python
 

--- a/cpp/src/server/dslPY/dslPY.cpp
+++ b/cpp/src/server/dslPY/dslPY.cpp
@@ -22,6 +22,7 @@
 #include <pv/nt.h>
 
 #include <pv/gatherV3Data.h>
+#include <pv/pyhelper.h>
 
 namespace epics { namespace masar { 
 
@@ -598,6 +599,7 @@ static NTTablePtr retrieveServiceConfigEvents(PyObject * list, long numeric)
 PVStructurePtr DSL_RDB::request(
     string const & functionName,shared_vector<const string> const & names,shared_vector<const string> const &values)
 {
+try{
     if (functionName.compare("getLiveMachine")==0) {
         NTMultiChannelPtr ntmultiChannel = getLiveMachine(values);
         return ntmultiChannel->getPVStructure();
@@ -730,6 +732,11 @@ PVStructurePtr DSL_RDB::request(
         PyGILState_Release(gstate);
         return pvReturn->getPVStructure();
     }
+}catch(python_exception& e){
+    PyErr_Print(); // TODO: print exception message/stack to string and return
+    PyErr_Clear();
+    throw epics::pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,"Python exception, check server log");
+}
 }
 
 DSLPtr createDSL_RDB()

--- a/cpp/src/server/service/masarService.cpp
+++ b/cpp/src/server/service/masarService.cpp
@@ -46,62 +46,49 @@ void MasarService::destroy()
 PVStructurePtr MasarService::request(
     PVStructurePtr const & pvArgument) throw (epics::pvAccess::RPCRequestException)
 {
-    assert(dslRdb.get() != NULL);
+    try{
+        assert(dslRdb.get() != NULL);
 
-    if(!NTNameValue::is_a(pvArgument->getStructure())) {
-        // support non NTNameValue Pair for some general purpose client, for example command line tools
-        string functionName;
-        PVStringPtr pvFunction = pvArgument->getSubFieldT<PVString>("function");
-        if (!pvFunction) {
+        string functionName(pvArgument->getSubFieldT<PVString>("function")->get());
+        if(functionName.empty()) {
             throw epics::pvAccess::RPCRequestException(
-                Status::STATUSTYPE_ERROR,"unknown MASAR function");
+                        Status::STATUSTYPE_ERROR,"pvArgument has an unsupported function");
         }
-        functionName = pvFunction->get();
-        if(functionName.size() < 1) {
-            throw epics::pvAccess::RPCRequestException(
-                Status::STATUSTYPE_ERROR,"pvArgument has an unsupported function");
-        }
-        StringArray fieldNames = pvArgument->getStructure()->getFieldNames();
-        size_t fieldcounts = (size_t) fieldNames.size();
-        shared_vector<string> names  (fieldcounts-1);
-        shared_vector<string> values (fieldcounts-1);
-        size_t counts = 0;
-        for (size_t i = 0; i < fieldcounts; i ++) {
-            if(fieldNames[i].compare("function")!=0) {
-                names[counts] = fieldNames[i];
-                values[counts] = pvArgument->getSubFieldT<PVString>(fieldNames[i])->get();
-                counts += 1;
+
+        if(!NTNameValue::is_a(pvArgument->getStructure())) {
+            // support non NTNameValue Pair for some general purpose client, for example command line tools
+
+            const StringArray& fieldNames = pvArgument->getStructure()->getFieldNames();
+            size_t fieldcounts = fieldNames.size();
+            shared_vector<string> names  (fieldcounts-1);
+            shared_vector<string> values (fieldcounts-1);
+            size_t counts = 0;
+            for (size_t i = 0; i < fieldcounts; i ++) {
+                if(fieldNames[i].compare("function")!=0) {
+                    names[counts] = fieldNames[i];
+                    values[counts] = pvArgument->getSubFieldT<PVString>(fieldNames[i])->get();
+                    counts += 1;
+                }
             }
-        }
-        try {
+
             PVStructurePtr result = dslRdb->request(functionName, freeze(names), freeze(values));
             return result;
-        } catch (std::exception &e) {
-            throw RPCRequestException(Status::STATUSTYPE_ERROR,
-                std::string("request failed ") + e.what());
-        }
-    } else{
-        string functionName;
-        PVStringPtr pvFunction = pvArgument->getSubField<PVString>("function");
-        if (!pvFunction) {
-            throw epics::pvAccess::RPCRequestException(
-                 Status::STATUSTYPE_ERROR,"unknown MASAR function");
-        }
-        functionName = pvFunction->get();
-        if(functionName.size()<1) {
-            throw epics::pvAccess::RPCRequestException(
-                Status::STATUSTYPE_ERROR,"pvArgument has an unsupported function");
-        }
-        try {
+        } else{
 
             const shared_vector<const string> name = pvArgument->getSubFieldT<PVStringArray>("name")->view();
             const shared_vector<const string> value = pvArgument->getSubFieldT<PVStringArray>("value")->view();
             PVStructurePtr result = dslRdb->request(functionName, name, value);
             return result;
-        } catch (std::exception &e) {
-            throw RPCRequestException(Status::STATUSTYPE_ERROR,
-                std::string("request failed ") + e.what());
         }
+
+    }catch(epics::pvAccess::RPCRequestException&){
+        throw;
+    }catch(std::exception& e){
+        // since request(RPCRequestException) in our base class has a throw() specifier,
+        // if anything else is thrown we abort() :P
+        // so must translate all exceptions to RPCRequestException.
+        throw epics::pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
+                                                   std::string("request failed ") + e.what());
     }
 }
 

--- a/cpp/src/server/service/masarService.cpp
+++ b/cpp/src/server/service/masarService.cpp
@@ -84,7 +84,7 @@ PVStructurePtr MasarService::request(
     }catch(epics::pvAccess::RPCRequestException&){
         throw;
     }catch(std::exception& e){
-        // since request(RPCRequestException) in our base class has a throw() specifier,
+        // since request() in our base class has a throw(RPCRequestException) specifier,
         // if anything else is thrown we abort() :P
         // so must translate all exceptions to RPCRequestException.
         throw epics::pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,

--- a/cpp/src/util/Makefile
+++ b/cpp/src/util/Makefile
@@ -1,0 +1,9 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+
+USR_INCLUDES += -I${PYTHON_BASE}/include/${PYTHON}
+
+INC += pyhelper.h
+
+include $(TOP)/configure/RULES
+

--- a/cpp/src/util/pyhelper.h
+++ b/cpp/src/util/pyhelper.h
@@ -1,0 +1,110 @@
+#ifndef PYHELPER_H
+#define PYHELPER_H
+
+#include <stdexcept>
+
+#include <Python.h>
+
+// Throw this to indicate that a python exception is active
+struct python_exception : public std::runtime_error
+{
+    python_exception() : std::runtime_error("python") {}
+    virtual ~python_exception() throw() {}
+};
+
+//! helper to indicate that the wrapped PyObject is a borrowed referenced for the caller
+struct borrowed {
+    PyObject *o;
+    explicit borrowed(PyObject *o) :o(o) {}
+};
+
+//! Smart pointer for python objects
+struct PyObj
+{
+    PyObject *obj;
+
+    PyObj() :obj(NULL) {}
+
+    //! Assumes caller already has a reference to this object
+    //! if o==NULL then assume a python exception has been raised
+    explicit PyObj(PyObject *o) :obj(o)
+    {
+        if(!obj)
+            throw python_exception();
+    }
+    //! Assumes caller does not have a reference to this object
+    //! if o==NULL then assume a python exception has been raised
+    explicit PyObj(const borrowed& b) :obj(b.o)
+    {
+        if(!obj)
+            throw python_exception();
+        Py_INCREF(obj);
+    }
+
+    ~PyObj()
+    {
+        Py_XDECREF(obj);
+    }
+
+    //! Explicitly fetch the underlying PyObject*
+    PyObject *get() {return obj;}
+    //! Implicitly fetch the underlying PyObject*
+    //operator PyObject*() { return obj; }
+
+    //! Give up control of this reference (no decrement)
+    PyObject *release() {
+        PyObject *ret=obj;
+        obj = NULL;
+        return ret;
+    }
+    //! Switch object being pointed to.
+    //! Any existing reference is decremented
+    //! if o==NULL then simply clear the reference
+    void reset(PyObject *o = 0)
+    {
+        Py_XDECREF(obj);
+        obj = o;
+    }
+
+    //! if o==NULL then assume a python exception has been raised
+    void reset(const borrowed& b)
+    {
+        if(!b.o)
+            throw python_exception();
+        Py_INCREF(b.o);
+        Py_XDECREF(obj);
+        obj = b.o;
+    }
+
+    PyObject& operator*() { return *obj; }
+    PyObject* operator->() { return obj; }
+
+private:
+    PyObj(const PyObj&);
+    PyObj& operator=(const PyObj&);
+};
+
+//! Scoped GIL locker
+struct PyLockGIL
+{
+    PyGILState_STATE state;
+    PyLockGIL() :state(PyGILState_Ensure()) {}
+    ~PyLockGIL() {
+        PyGILState_Release(state);
+    }
+private:
+    PyLockGIL(const PyLockGIL&);
+    PyLockGIL& operator=(const PyLockGIL&);
+};
+
+//! Scoped GIL unlocker
+struct PyUnlockGIL
+{
+    PyThreadState *state;
+    PyUnlockGIL() :state(PyEval_SaveThread()) {}
+    ~PyUnlockGIL() { PyEval_RestoreThread(state); }
+};
+
+#define EXECTOPY(klass, PYEXC) catch(klass& e) { PyErr_SetString(PyExc_##PYEXC, e.what()); }
+
+#endif /* PYHELPER_H */


### PR DESCRIPTION
This branch fixes the crash reported by @jbobnar

> terminate called after throwing an instance of ’std::runtime_error’
> what(): Failed to get field: function (function not found)
> Signal 6 caught...
> Aborted (core dumped)

Which is due to a violation of the throw(RPCRequestException) spec. on the RPCService::request() method.  Now request() catches and re-throws all std::exception as RPCRequestException.

Note that the throw() specifier will be removed in future PVAccessCPP releases epics-base/pvAccessCPP#25

Also add pyhelper.h with some utility classes to avoid come common bugs.  Chiefly the PyObj "smart" pointer to avoid explicit Py_INCREF/DECREF.